### PR TITLE
Iterator on JSON objects

### DIFF
--- a/examples/json_stream_advanced.py
+++ b/examples/json_stream_advanced.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+import sys
+import time
+
+import adafruit_json_stream as json_stream
+
+# import json_stream
+
+
+class FakeResponse:
+    def __init__(self, file):
+        self.file = file
+
+    def iter_content(self, chunk_size):
+        while True:
+            yield self.file.read(chunk_size)
+
+
+f = open(sys.argv[1], "rb")  # pylint: disable=consider-using-with
+obj = json_stream.load(FakeResponse(f).iter_content(32))
+
+
+def find_keys(obj, keys):
+    """If we don't know the order in which the keys are,
+    go through all of them and pick the ones we want"""
+    out = dict()
+    # iterate on the items of an object
+    for key, value in obj.items():
+        if key in keys:
+            # if it's a sub object, get it all
+            if isinstance(value, json_stream.Transient):
+                value = value.as_object()
+            out[key] = value
+    return out
+
+def time_to_date(stamp):
+    tt = time.localtime(stamp)
+    month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][tt.tm_mon]
+    return f"{tt.tm_mday:2d}th of {month}"
+
+def ftoc(temp):
+    return (temp - 32) * 5 / 9
+
+currently = obj["currently"]
+print("Currently:")
+print("    ", time_to_date(currently["time"]))
+print("    ", currently["icon"])
+
+# iterate on the content of a list
+for i, day in enumerate(obj["daily"]["data"]):
+    day_items = find_keys(day, ("time", "summary", "temperatureHigh"))
+    date = time_to_date(day_items["time"])
+    print(
+        f'On {date}: {day_items["summary"]},',
+        f'Max: {int(day_items["temperatureHigh"])}F',
+        f'({int(ftoc(day_items["temperatureHigh"]))}C)'
+    )
+
+    if i > 4:
+        break

--- a/examples/json_stream_local_file_advanced.py
+++ b/examples/json_stream_local_file_advanced.py
@@ -23,31 +23,52 @@ f = open(sys.argv[1], "rb")  # pylint: disable=consider-using-with
 obj = json_stream.load(FakeResponse(f).iter_content(32))
 
 
-def find_keys(obj, keys):
+def find_keys(haystack, keys):
     """If we don't know the order in which the keys are,
     go through all of them and pick the ones we want"""
-    out = dict()
+    out = {}
     # iterate on the items of an object
-    for key, value in obj.items():
+    for key in haystack:
         if key in keys:
+            # retrieve the value only if needed
+            value = haystack[key]
             # if it's a sub object, get it all
-            if isinstance(value, json_stream.Transient):
+            if hasattr(value, "as_object"):
                 value = value.as_object()
             out[key] = value
     return out
 
+
+months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+]
+
+
 def time_to_date(stamp):
     tt = time.localtime(stamp)
-    month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][tt.tm_mon]
+    month = months[tt.tm_mon]
     return f"{tt.tm_mday:2d}th of {month}"
+
 
 def ftoc(temp):
     return (temp - 32) * 5 / 9
 
+
 currently = obj["currently"]
 print("Currently:")
-print("    ", time_to_date(currently["time"]))
-print("    ", currently["icon"])
+print(" ", time_to_date(currently["time"]))
+print(" ", currently["icon"])
 
 # iterate on the content of a list
 for i, day in enumerate(obj["daily"]["data"]):
@@ -56,7 +77,7 @@ for i, day in enumerate(obj["daily"]["data"]):
     print(
         f'On {date}: {day_items["summary"]},',
         f'Max: {int(day_items["temperatureHigh"])}F',
-        f'({int(ftoc(day_items["temperatureHigh"]))}C)'
+        f'({int(ftoc(day_items["temperatureHigh"]))}C)',
     )
 
     if i > 4:

--- a/tests/test_json_stream.py
+++ b/tests/test_json_stream.py
@@ -685,3 +685,22 @@ def test_as_object_grabbing_multiple_subscriptable_levels_again_after_passed_rai
     assert next(dict_1["sub_list"]) == "a"
     with pytest.raises(KeyError, match="sub_dict"):
         dict_1["sub_dict"]["sub_dict_name"]
+
+
+def test_iterating_keys(dict_with_keys):
+    """Iterate through keys of a simple object"""
+
+    bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
+    stream = adafruit_json_stream.load(bytes_io_chunk)
+    output = list(stream)
+    assert output == ["field_1", "field_2", "field_3"]
+
+
+def test_iterating_items(dict_with_keys):
+    """Iterate through items of a simple object"""
+
+    bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
+    stream = adafruit_json_stream.load(bytes_io_chunk)
+    output = list(stream.items())
+    assert output == [("field_1", 1), ("field_2", 2), ("field_3", 3)]
+

--- a/tests/test_json_stream.py
+++ b/tests/test_json_stream.py
@@ -688,7 +688,7 @@ def test_as_object_grabbing_multiple_subscriptable_levels_again_after_passed_rai
 
 
 def test_iterating_keys(dict_with_keys):
-    """Iterate through keys of a simple object"""
+    """Iterate through keys of a simple object."""
 
     bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
     stream = adafruit_json_stream.load(bytes_io_chunk)
@@ -697,10 +697,29 @@ def test_iterating_keys(dict_with_keys):
 
 
 def test_iterating_items(dict_with_keys):
-    """Iterate through items of a simple object"""
+    """Iterate through items of a simple object."""
 
     bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
     stream = adafruit_json_stream.load(bytes_io_chunk)
     output = list(stream.items())
     assert output == [("field_1", 1), ("field_2", 2), ("field_3", 3)]
 
+
+def test_iterating_keys_after_get(dict_with_keys):
+    """Iterate through keys of a simple object after an item has already been read."""
+
+    bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
+    stream = adafruit_json_stream.load(bytes_io_chunk)
+    assert stream["field_1"] == 1
+    output = list(stream)
+    assert output == ["field_2", "field_3"]
+
+
+def test_iterating_items_after_get(dict_with_keys):
+    """Iterate through items of a simple object after an item has already been read."""
+
+    bytes_io_chunk = BytesChunkIO(dict_with_keys.encode())
+    stream = adafruit_json_stream.load(bytes_io_chunk)
+    assert stream["field_1"] == 1
+    output = list(stream.items())
+    assert output == [("field_2", 2), ("field_3", 3)]


### PR DESCRIPTION
This adds 2 ways to iterate on an object's items following the APIs of `dict()`.

- The main iterator is `for key in obj` it iterates over the keys without consuming or loading the values. The current key's value can then be accessed with `obj[key]`.
- The `TransientObject.items()` method will iterate on item tuples fetching both key and value with `for key, value in obj.items()`. Because it fetches every value (be it a basic type or a `Transient` instance), it will use more memory.

So this works, although note that you can only get the `key` once unless it's a container too.
```py
for key in stream["some_dict"]:
    if key == "needle":
        print(stream["some_dict"][key])
```

The new example `json_stream_local_file_advanced.py` uses the iterator to find keys that match a list of expected keys and returns a python dict that contains only those items. It's an example of how to retrieve a set of keys when the order is unknown.

I am not sure how to best document the iterator outside of the `items()` property.