### PR TITLE
Adds a non-blank description to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
 
 [project]
 name = "adafruit-circuitpython-json-stream"
-description = ""
+description = "Minimal reimplementation of json-stream for CircuitPython"
 version = "0.0.0+auto.0"
 readme = "README.rst"
 authors = [


### PR DESCRIPTION
Ads a non-blank description to the project.description field in pyproject.toml. I'm hoping this will assist the Adafruit_CircuitPython_Bundle tooling.